### PR TITLE
Netbsd 1

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -191,8 +191,8 @@ MINC2_LIBS = -lminc_io -lvolume_io2 -lminc2 -lnetcdf -lhdf5 -lz -L${HOME}/local/
 
 # Flags to enable native support for downloading files from the network.
 # ( http://curl.haxx.se/libcurl/ )
-CURL_CFLAGS = -Dcimg_use_curl
-CURL_LIBS = -lcurl
+CURL_CFLAGS = -Dcimg_use_curl `pkg-config --cflags libcurl`
+CURL_LIBS = `pkg-config --libs libcurl`
 
 # Flags to enable native support of webcams and video streaming, using the OpenCV library.
 # This requires the presence of the OpenCV include and library files.

--- a/src/Makefile
+++ b/src/Makefile
@@ -211,11 +211,10 @@ EXR_LIBS = -lIlmImf -lHalf
 
 # Flags to enable the use of the FFTW3 library.
 # This requires the presence of the FFTW3 include and library files.
-FFTW_CFLAGS = -Dcimg_use_fftw3
-ifeq ($(OSTYPE),msys)
-FFTW_LIBS = -lfftw3
-else
-FFTW_LIBS = -lfftw3 -lfftw3_threads
+FFTW_CFLAGS = -Dcimg_use_fftw3 `pkg-config --cflags fftw3`
+FFTW_LIBS = `pkg-config --libs fftw3`
+ifneq ($(OSTYPE),msys)
+FFTW_LIBS += -lfftw3_threads
 endif
 
 # Flags to enable the use of the BOARD library.

--- a/src/Makefile
+++ b/src/Makefile
@@ -171,8 +171,8 @@ GDI32_LIBS = -lgdi32
 
 # Flags to enable native support for PNG image files, using the PNG library.
 # This requires the presence of the libpng include and library files.
-PNG_CFLAGS = -Dcimg_use_png
-PNG_LIBS = -lpng -lz
+PNG_CFLAGS = -Dcimg_use_png `pkg-config --cflags libpng`
+PNG_LIBS = `pkg-config --libs libpng`
 
 # Flags to enable native support for JPEG image files, using the JPEG library.
 # This requires the presence of the libjpeg include and library files.

--- a/src/Makefile
+++ b/src/Makefile
@@ -161,8 +161,8 @@ X11_LIBS = `pkg-config --libs x11` -lpthread #`pkg-config --libs xrandr`
 
 # Flags to enable fast display, using XShm.
 # This requires the presence of the X11 extension include and library files.
-XSHM_CFLAGS = -Dcimg_use_xshm
-XSHM_LIBS = -L$(USR)/X11R6/lib -lXext
+XSHM_CFLAGS = -Dcimg_use_xshm `pkg-config --cflags xcb-shm`
+XSHM_LIBS = `pkg-config --libs xcb-shm`
 
 # Flags to enable image display, using GDI32.
 # This requires the presence of the GDI32 include and library files.

--- a/src/Makefile
+++ b/src/Makefile
@@ -98,8 +98,8 @@ endif
 PRERELEASE_CFLAGS = -Dgmic_prerelease="\\\"`date +%m%d%y`\\\""
 
 # Flags that are mandatory to compile 'gmic'.
-MANDATORY_CFLAGS = -Dgmic_build -Dcimg_use_zlib -I$(USR)/$(INCLUDE) $(PRERELEASE_CFLAGS)
-MANDATORY_LIBS = -lz
+MANDATORY_CFLAGS = -Dgmic_build -Dcimg_use_zlib `pkg-config --cflags zlib` $(PRERELEASE_CFLAGS)
+MANDATORY_LIBS = `pkg-config --libs zlib`
 ifndef NO_SRIPDLIB
 MANDATORY_CFLAGS += -std=c++11
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -196,8 +196,8 @@ CURL_LIBS = `pkg-config --libs libcurl`
 
 # Flags to enable native support of webcams and video streaming, using the OpenCV library.
 # This requires the presence of the OpenCV include and library files.
-OPENCV_CFLAGS = -Dcimg_use_opencv  `pkg-config opencv --cflags` -I/usr/include/opencv
-OPENCV_LIBS = `pkg-config opencv --libs` -lopencv_core -lopencv_highgui
+OPENCV_CFLAGS = -Dcimg_use_opencv  `pkg-config opencv --cflags`
+OPENCV_LIBS = `pkg-config opencv --libs`
 
 # Flags to enable native support of most classical image file formats, using the GraphicsMagick++ library.
 # This requires the presence of the GraphicsMagick++ include and library files.

--- a/src/Makefile
+++ b/src/Makefile
@@ -78,6 +78,9 @@ ifeq ($(OS),FreeBSD)
 OS = Unix
 USR = /usr/local
 endif
+ifeq ($(OS),NetBSD)
+OS = Unix
+endif
 LIB=lib
 BIN=bin
 INCLUDE=include

--- a/src/Makefile
+++ b/src/Makefile
@@ -201,12 +201,8 @@ OPENCV_LIBS = `pkg-config opencv --libs`
 
 # Flags to enable native support of most classical image file formats, using the GraphicsMagick++ library.
 # This requires the presence of the GraphicsMagick++ include and library files.
-MAGICK_CFLAGS = -Dcimg_use_magick -I$(USR)/$(INCLUDE)/GraphicsMagick
-ifeq ($(OS),Darwin)
-MAGICK_LIBS = -L$(USR)/$(LIB) -lGraphicsMagick++ -lGraphicsMagick -llcms -ltiff -lfreetype -ljpeg -lpng -lbz2 -lxml2 -lz -lm -lltdl
-else
-MAGICK_LIBS = -lGraphicsMagick++
-endif
+MAGICK_CFLAGS = -Dcimg_use_magick `pkg-config --cflags GraphicsMagick++`
+MAGICK_LIBS = `pkg-config --libs GraphicsMagick++`
 
 # Flags to enable native support of EXR file format, using the OpenEXR library/
 # This requires the presence of the OpenEXR include and library files.

--- a/src/Makefile
+++ b/src/Makefile
@@ -156,8 +156,8 @@ OPENMP_LIBS = -lgomp
 # Flags to enable image display, using X11
 # (keep /usr/ dirname here since X11 is located in /usr/ on Mac too).
 # This requires the presence of the X11 include and library files.
-X11_CFLAGS = -Dcimg_display=1 -Dcimg_appname=\\\"gmic\\\" -I/usr/X11R6/include #-Dcimg_use_xrandr
-X11_LIBS = -L/usr/X11R6/lib -lX11 -lpthread #-lXrandr
+X11_CFLAGS = -Dcimg_display=1 -Dcimg_appname=\\\"gmic\\\" `pkg-config --cflags x11` #-Dcimg_use_xrandr
+X11_LIBS = `pkg-config --libs x11` -lpthread #`pkg-config --libs xrandr`
 
 # Flags to enable fast display, using XShm.
 # This requires the presence of the X11 extension include and library files.

--- a/src/Makefile
+++ b/src/Makefile
@@ -181,8 +181,8 @@ JPEG_LIBS = -ljpeg
 
 # Flags to enable native support for TIFF image files, using the TIFF library.
 # This requires the presence of the libtiff include and library files.
-TIFF_CFLAGS = -Dcimg_use_tiff
-TIFF_LIBS = -ltiff
+TIFF_CFLAGS = -Dcimg_use_tiff `pkg-config --cflags libtiff-4`
+TIFF_LIBS = `pkg-config --libs libtiff-4`
 
 # Flags to enable native support for MINC2 image files, using the MINC2 library.
 # ( http://en.wikibooks.org/wiki/MINC/Reference/MINC2.0_Users_Guide )


### PR DESCRIPTION
This is first go to enable native NetBSD support of GMIC.

In general NetBSD ships with multiplatform pkgsrc framework. We need custom paths for includes, libs, rpath etc. If we are without autotools (or similar build system) it's handled by pkg-config.

With more local changes it's working for me fine as a GIMP plugin. Thank you!