### PR TITLE
Add print-% target to investigate variables in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -380,6 +380,8 @@ GMICOL_LIBS = $(MANDATORY_LIBS) $(PARALLEL_LIBS) $(PNG_LIBS) $(JPEG_LIBS) $(ZLIB
 #--------------------------
 
 # Main default entries.
+print-%: ; @echo $*=$($*)
+
 all: CImg.h gmic_stdlib.h
 ifeq ($(OS),Unix)
 	@echo "**"


### PR DESCRIPTION
This simply adds a print-%: target to allow printing variables
for the make process.  This is just to help diagnose what might
be going on.

Can be used by calling `$ make print-GMIC_CLI_CFLAGS` for instance.
This should work for any variables in the Makefile.