### PR TITLE
CMakeLists.txt - require at least cmake version 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@
 #  knowledge of the CeCILL and CeCILL-C licenses and that you accept its terms.
 #
 
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.1)
 cmake_policy(SET CMP0046 OLD)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)


### PR DESCRIPTION
Supporting a version of cmake that was released in 2012 doesn't really make sense. Version 3.1 seems a safe bet, though I haven't tested it.