### PR TITLE
Misc. typos

### DIFF
--- a/src/gmic.cpp
+++ b/src/gmic.cpp
@@ -2239,7 +2239,7 @@ unsigned int gmic::hashcode(const char *const str, const bool is_variable) {
   return hash&(gmic_comslots - 1);
 }
 
-// Tells if the the implementation of a G'MIC command contains arguments.
+// Tells if the implementation of a G'MIC command contains arguments.
 bool gmic::command_has_arguments(const char *const command) {
   if (!command || !*command) return false;
   for (const char *s = std::strchr(command,'$'); s; s = std::strchr(s,'$')) {
@@ -8065,7 +8065,7 @@ gmic& gmic::_run(const CImgList<char>& commands_line, unsigned int& position,
         //-----------------------------
       gmic_commands_l :
 
-        // Start local environnement.
+        // Start local environment.
         if (!std::strcmp("local",command)) {
           if (is_debug_info && debug_line!=~0U) {
             cimg_snprintf(argx,_argx.width(),"*local#%u",debug_line);
@@ -8615,7 +8615,7 @@ gmic& gmic::_run(const CImgList<char>& commands_line, unsigned int& position,
             nb_randoms = cimg::round(nb_randoms);
             if (ind0) initialization = &images[*ind0];
             print(images,0,"Estimate correspondence map between image%s and patch image [%u], "
-                  "using %gx%gx%g patches, %g iteration%s, %g randomization%s and occurence penalization %g "
+                  "using %gx%gx%g patches, %g iteration%s, %g randomization%s and occurrence penalization %g "
                   "(%sscore returned).",
                   gmic_selection.data(),
                   *ind,

--- a/src/gmic_stdlib.gmic
+++ b/src/gmic_stdlib.gmic
@@ -3204,7 +3204,7 @@ ow :
   _outputw
 
 #@cli outputw
-#@cli : Output selected images by overwritting their original location.
+#@cli : Output selected images by overwriting their original location.
 #@cli : (eq. to 'ow').
 outputw :
   v - _gmic_s="$?" v +
@@ -6034,7 +6034,7 @@ decompress_rle :
     # Retrieve original data dimension and min value.
     y whds={0,@0-3} im={0,@4} is_binary_data={0,@5} rows 6,100%
 
-    # Transform RLE data to list of pairs {nb_occurences,value}.
+    # Transform RLE data to list of pairs {nb_occurrences,value}.
     if $is_binary_data  # Decode for binary data.
       +>= 0 abs[0] a x
     else # Decode for arbitrary data
@@ -23199,7 +23199,7 @@ x_quantize_rgb : check "isint(${1=16}) && $1>1"
       done a[-{colors,s}--1] c
       rm[centroids] nm. centroids
 
-      # Reassign ununsed centroids.
+      # Reassign unused centroids.
       +>>[colors] 8 channels. 0 histogram. {centroids,w},0,{centroids,w-1}
       cmax={xM}
       repeat {w} if {!i($>)} point[centroids] $>,0,0,1,{centroids,I($cmax)} point[centroids] $>,0,0,-0.001,${-RGB} fi done
@@ -24500,7 +24500,7 @@ gui_filter_sources : skip ${1=0},${2=1}
   l[] i cimgz:${_path_rc}gui_filter_sources onfail endl # Include other user-defined filters sources.
   ({'{/$_path_user}'}) # Include local '.gmic' (or 'user.gmic') file.
 
-# Function that alway returns a valid preview size.
+# Function that always returns a valid preview size.
 gui_preview_wh :
   u {0$_preview_width?[0$_preview_width,0$_preview_height]:[400,400]}
 


### PR DESCRIPTION
Found via`codespell -q 3 -L dur,nd,ang,ans,ba,uint,sinc,ois,ot`