### PR TITLE
CMake: add libcurl support for the cli app and base library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ option(BUILD_CLI "Build the CLI interface" ON)
 option(BUILD_MAN "Build the manpage" ON)
 option(BUILD_BASH_COMPLETION "Build Bash completion" ON)
 option(CUSTOM_CFLAGS "Override default compiler optimization flags" OFF)
+option(ENABLE_CURL "Add support for curl" ON)
 option(ENABLE_X "Add support for X11" ON)
 option(ENABLE_FFMPEG "Add support for FFMpeg" ON)
 option(ENABLE_FFTW "Add support for FFTW" ON)
@@ -133,6 +134,16 @@ if(ZLIB_FOUND)
   set(COMPILE_FLAGS "${COMPILE_FLAGS} -Dcimg_use_zlib")
   include_directories(${ZLIB_INCLUDE_DIRS})
   link_directories(${ZLIB_LIBRARY_DIRS})
+endif()
+
+# curl support
+if(ENABLE_CURL)
+  find_package(CURL)
+endif()
+if(CURL_FOUND)
+  set(COMPILE_FLAGS "${COMPILE_FLAGS} -Dcimg_use_curl")
+  include_directories(${CURL_INCLUDE_DIRS})
+  link_directories(${CURL_LIBRARY_DIRS})
 endif()
 
 #X11 support
@@ -287,6 +298,7 @@ if(BUILD_LIB)
     ${OPENEXR_LIBRARIES}
     ${OPENCV_LIBRARIES}
     ${ZLIB_LIBRARIES}
+    ${CURL_LIBRARIES}
     ${FFTW3_LIBRARIES}
     ${EXTRA_LIBRARIES}
   )
@@ -315,6 +327,7 @@ if(BUILD_LIB_STATIC)
     ${OPENEXR_LIBRARIES}
     ${OPENCV_LIBRARIES}
     ${ZLIB_LIBRARIES}
+    ${CURL_LIBRARIES}
     ${FFTW3_LIBRARIES}
     ${EXTRA_LIBRARIES}
   )
@@ -344,6 +357,7 @@ if(BUILD_CLI)
       ${OPENEXR_LIBRARIES}
       ${OPENCV_LIBRARIES}
       ${ZLIB_LIBRARIES}
+      ${CURL_LIBRARIES}
       ${FFTW3_LIBRARIES}
       ${EXTRA_LIBRARIES}
     )


### PR DESCRIPTION
This allows for using libcurl support instead of trying to directly execute the curl binary on the target system.