### PR TITLE
Proposing github sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://libreart.info/en/projects/gmic


### PR DESCRIPTION
See https://help.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository
Already added for gmic-py and gmic-blender