### PR TITLE
cmake: Move all dependencies to separate targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,10 @@ if(BUILD_BASH_COMPLETION)
     COMMAND LD_LIBRARY_PATH=${GMIC_BINARIES_PATH} ${GMIC_BINARIES_PATH}/gmic -v - ${CMAKE_SOURCE_DIR}/src/gmic_stdlib.gmic raw:${CMAKE_SOURCE_DIR}/src/gmic_stdlib.gmic,uchar -document_gmic bash > ${CMAKE_BINARY_DIR}/resources/gmic_bashcompletion.sh
   )
   add_custom_target(bashcompletion ALL DEPENDS ${CMAKE_BINARY_DIR}/resources/gmic_bashcompletion.sh)
+  install(FILES ${CMAKE_BINARY_DIR}/resources/gmic_bashcompletion.sh
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/bash-completion/completions
+    RENAME gmic
+  )
 endif()
 
 include(CMakePackageConfigHelpers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,7 @@ if(BUILD_MAN)
   add_custom_command(
     OUTPUT ${CMAKE_BINARY_DIR}/man/gmic.1
     DEPENDS gmic
-    COMMAND LD_LIBRARY_PATH=${GMIC_BINARIES_PATH} ${GMIC_BINARIES_PATH}/gmic -v - ${CMAKE_SOURCE_DIR}/src/gmic_stdlib.gmic raw:${CMAKE_SOURCE_DIR}/src/gmic_stdlib.gmic,uchar -__help man 2> ${CMAKE_BINARY_DIR}/man/gmic.1
+    COMMAND LD_LIBRARY_PATH=${GMIC_BINARIES_PATH} ${GMIC_BINARIES_PATH}/gmic -v - ${CMAKE_SOURCE_DIR}/src/gmic_stdlib.gmic raw:${CMAKE_SOURCE_DIR}/src/gmic_stdlib.gmic,uchar -__help man > ${CMAKE_BINARY_DIR}/man/gmic.1
   )
   add_custom_target(man ALL DEPENDS ${CMAKE_BINARY_DIR}/man/gmic.1)
   install(FILES ${CMAKE_BINARY_DIR}/man/gmic.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1/)
@@ -207,7 +207,7 @@ if(BUILD_BASH_COMPLETION)
   add_custom_command(
     OUTPUT ${CMAKE_BINARY_DIR}/resources/gmic_bashcompletion.sh
     DEPENDS gmic
-    COMMAND LD_LIBRARY_PATH=${GMIC_BINARIES_PATH} ${GMIC_BINARIES_PATH}/gmic -v - ${CMAKE_SOURCE_DIR}/src/gmic_stdlib.gmic raw:${CMAKE_SOURCE_DIR}/src/gmic_stdlib.gmic,uchar -document_gmic bash 2> ${CMAKE_BINARY_DIR}/resources/gmic_bashcompletion.sh
+    COMMAND LD_LIBRARY_PATH=${GMIC_BINARIES_PATH} ${GMIC_BINARIES_PATH}/gmic -v - ${CMAKE_SOURCE_DIR}/src/gmic_stdlib.gmic raw:${CMAKE_SOURCE_DIR}/src/gmic_stdlib.gmic,uchar -document_gmic bash > ${CMAKE_BINARY_DIR}/resources/gmic_bashcompletion.sh
   )
   add_custom_target(bashcompletion ALL DEPENDS ${CMAKE_BINARY_DIR}/resources/gmic_bashcompletion.sh)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,7 @@
 #  knowledge of the CeCILL and CeCILL-C licenses and that you accept its terms.
 #
 
-cmake_minimum_required(VERSION 3.8)
-cmake_policy(SET CMP0046 OLD)
+cmake_minimum_required(VERSION 3.9.4)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
   message("Build directory is equal to source directory. Binaries will be put in the src directory.")
@@ -71,9 +70,14 @@ set(CXX_STANDARD_REQUIRED ON)
 
 project(gmic CXX C)
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 find_package(PkgConfig)
 include(FeatureSummary)
 include(GNUInstallDirs)
+
+find_package(CImg REQUIRED)
+find_package(GMicStdlib REQUIRED)
 
 # options controlling the build process
 option(BUILD_LIB "Build the GMIC shared library" ON)
@@ -82,18 +86,6 @@ option(BUILD_CLI "Build the CLI interface" ON)
 option(BUILD_MAN "Build the manpage" ON)
 option(BUILD_BASH_COMPLETION "Build Bash completion" ON)
 option(CUSTOM_CFLAGS "Override default compiler optimization flags" OFF)
-option(ENABLE_CURL "Add support for curl" ON)
-option(ENABLE_X "Add support for X11" ON)
-option(ENABLE_FFMPEG "Add support for FFMpeg" ON)
-option(ENABLE_FFTW "Add support for FFTW" ON)
-option(ENABLE_GRAPHICSMAGICK "Add support for GrahicsMagick" ON)
-option(ENABLE_JPEG "Add support for handling images in Jpeg format" ON)
-option(ENABLE_OPENCV "Add support for OpenCV" ON)
-option(ENABLE_OPENEXR "Add support for handling images in EXR format" ON)
-option(ENABLE_OPENMP "Add support for parallel processing" ON)
-option(ENABLE_PNG "Add support for handling images in PNG format" ON)
-option(ENABLE_TIFF "Add support for handling images in Tiff format" ON)
-option(ENABLE_ZLIB "Add support for data compression via Zlib" ON)
 option(ENABLE_DYNAMIC_LINKING "Dynamically link the binaries to the GMIC shared library" OFF)
 option(ENABLE_LTO "Enable -flto (Link Time Optimizer) on gcc and clang" OFF)
 
@@ -102,7 +94,6 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 # compile flags
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/modules)
 set(CMAKE_POSITION_INDEPENDENT_CODE True)
 
 set(COMPILE_FLAGS "-Dgmic_build -Dcimg_use_vt100 -Dgmic_is_parallel -Dcimg_use_abort")
@@ -116,131 +107,16 @@ if(NOT "${PRERELEASE_TAG}" STREQUAL "")
   set(COMPILE_FLAGS "${COMPILE_FLAGS} -Dgmic_prerelease=\"${PRERELEASE_TAG}\"")
 endif()
 
-set(EXTRA_LIBRARIES)
-set(CLI_COMPILE_FLAGS)
-
-# OpenMP support
-if(ENABLE_OPENMP)
-  if(NOT APPLE)
-    set(COMPILE_FLAGS "${COMPILE_FLAGS} -fopenmp -Dcimg_use_openmp")
-    list(APPEND EXTRA_LIBRARIES "-lgomp")
-  endif()
-endif()
-
-# Zlib support
-if(ENABLE_ZLIB)
-  find_package(ZLIB)
-endif()
-if(ZLIB_FOUND)
-  set(COMPILE_FLAGS "${COMPILE_FLAGS} -Dcimg_use_zlib")
-  include_directories(${ZLIB_INCLUDE_DIRS})
-  link_directories(${ZLIB_LIBRARY_DIRS})
-endif()
-
-# Curl support
-if(ENABLE_CURL)
-  find_package(CURL)
-endif()
-if(CURL_FOUND)
-  set(COMPILE_FLAGS "${COMPILE_FLAGS} -Dcimg_use_curl")
-  include_directories(${CURL_INCLUDE_DIRS})
-  link_directories(${CURL_LIBRARY_DIRS})
-endif()
-
-# X11 support
-if(ENABLE_X)
-  find_package(X11)
-endif()
-if(X11_FOUND)
-  set(COMPILE_FLAGS "${COMPILE_FLAGS} -Dcimg_display=1 -Dcimg_appname=\\\"gmic\\\"")
-  include_directories(${X11_INCLUDE_DIR})
-  include_directories(${X11_INCLUDE_DIRS})
-  link_directories(${X11_LIBRARY_DIR})
-  link_directories(${X11_LIBRARY_DIRS})
-else()
-  set(COMPILE_FLAGS "${COMPILE_FLAGS} -Dcimg_display=0 -Dcimg_appname=\\\"gmic\\\"")
-endif()
-message( "X11_INCLUDE_DIR: " ${X11_INCLUDE_DIR} )
-message( "X11_INCLUDE_DIRs: " ${X11_INCLUDE_DIRs} )
-message( "X11_LIBRARY_DIR: " ${X11_LIBRARY_DIR} )
-message( "X11_LIBRARY_DIRS: " ${X11_LIBRARY_DIRS} )
-if(X11_XShm_FOUND)
-  set(COMPILE_FLAGS "${COMPILE_FLAGS} -Dcimg_use_xshm")
-endif()
-
-if(ENABLE_FFTW)
-  pkg_check_modules(FFTW3 fftw3>=3.0)
-endif()
-if(FFTW3_FOUND)
-  set(COMPILE_FLAGS "${COMPILE_FLAGS} -Dcimg_use_fftw3")
-  include_directories(${FFTW3_INCLUDE_DIRS})
-  link_directories(${FFTW3_LIBRARY_DIRS})
-
-  find_library(FFTW3_THREADS_LIB fftw3_threads PATHS ${FFTW3_LIBRARY_DIRS})
-  if(FFTW3_THREADS_LIB STREQUAL "FFTW3_THREADS_LIB-NOTFOUND")
-    set(COMPILE_FLAGS "${COMPILE_FLAGS} -Dcimg_use_fftw3_singlethread")
+if (ENABLE_LTO)
+  # https://stackoverflow.com/a/47370726/160386
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT supported OUTPUT error)
+  if(supported)
+    message(STATUS "IPO / LTO enabled")
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
   else()
-    list(APPEND EXTRA_LIBRARIES "-lfftw3_threads")
+    message(STATUS "IPO / LTO not supported: <${error}>")
   endif()
-endif()
-
-if(ENABLE_OPENCV)
-  pkg_check_modules(OPENCV opencv)
-endif()
-if(OPENCV_FOUND)
-  set(CLI_COMPILE_FLAGS "${CLI_COMPILE_FLAGS} -Dcimg_use_opencv")
-  include_directories(${OPENCV_INCLUDE_DIRS})
-  link_directories(${OPENCV_LIBRARY_DIRS})
-endif()
-
-if(ENABLE_GRAPHICSMAGICK)
-  pkg_check_modules(GRAPHICSMAGICK GraphicsMagick++)
-endif()
-if(GRAPHICSMAGICK_FOUND)
-  set(CLI_COMPILE_FLAGS "${CLI_COMPILE_FLAGS} -Dcimg_use_magick")
-  include_directories(${GRAPHICSMAGICK_INCLUDE_DIRS})
-  link_directories(${GRAPHICSMAGICK_LIBRARY_DIRS})
-endif()
-
-if(ENABLE_TIFF)
-  find_package(TIFF)
-endif()
-if(TIFF_FOUND)
-  set(CLI_COMPILE_FLAGS "${CLI_COMPILE_FLAGS} -Dcimg_use_tiff")
-  include_directories(${TIFF_INCLUDE_DIRS})
-  link_directories(${TIFF_LIBRARY_DIRS})
-endif()
-
-if(ENABLE_PNG)
-  find_package(PNG)
-endif()
-if(PNG_FOUND)
-  set(CLI_COMPILE_FLAGS "${CLI_COMPILE_FLAGS} -Dcimg_use_png")
-  include_directories(${PNG_INCLUDE_DIRS})
-  link_directories(${PNG_LIBRARY_DIRS})
-endif()
-
-if(ENABLE_JPEG)
-  find_package(JPEG)
-endif()
-if(JPEG_FOUND)
-  set(CLI_COMPILE_FLAGS "${CLI_COMPILE_FLAGS} -Dcimg_use_jpeg")
-  include_directories(${JPEG_INCLUDE_DIRS})
-  link_directories(${JPEG_LIBRARY_DIRS})
-endif()
-
-if(ENABLE_OPENEXR)
-  pkg_check_modules(OPENEXR OpenEXR)
-endif()
-if(OPENEXR_FOUND)
-  set(CLI_COMPILE_FLAGS "${CLI_COMPILE_FLAGS} -Dcimg_use_openexr")
-  include_directories(${OPENEXR_INCLUDE_DIRS})
-  link_directories(${OPENEXR_LIBRARY_DIRS})
-endif()
-
-if (ENABLE_LTO AND (CMAKE_COMPILER_IS_GNUCC OR (CMAKE_CSS_COMPILER_IS STREQUAL "Clang")))
-  set(CLI_COMPILE_FLAGS "${CLI_COMPILE_FLAGS} -flto")
-  list(APPEND EXTRA_LIBRARIES "-flto")
 endif()
 
 if(ENABLE_DYNAMIC_LINKING)
@@ -249,20 +125,6 @@ if(ENABLE_DYNAMIC_LINKING)
   endif()
   set(CMAKE_SKIP_RPATH TRUE)
 endif()
-
-# CImg.h header
-if(NOT EXISTS ${CMAKE_SOURCE_DIR}/src/CImg.h)
-  file(DOWNLOAD https://github.com/dtschump/CImg/raw/master/CImg.h ${CMAKE_SOURCE_DIR}/src/CImg.h)
-  execute_process(COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_SOURCE_DIR}/src/CImg.h)
-endif()
-
-# gmic_stdlib.h header
-if(NOT EXISTS ${CMAKE_SOURCE_DIR}/src/gmic_stdlib.h)
-  file(DOWNLOAD https://gmic.eu/gmic_stdlib.h ${CMAKE_SOURCE_DIR}/src/gmic_stdlib.h)
-  execute_process(COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_SOURCE_DIR}/src/gmic_stdlib.h)
-endif()
-
-add_custom_target(gmic_extra_headers DEPENDS src/CImg.h src/gmic_stdlib.h)
 
 set(CMAKE_CXX_FLAGS_DEBUG "-g -ansi -Wall -Wextra -pedantic -Dcimg_verbosity=3 ${COMPILE_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${COMPILE_FLAGS}")
@@ -275,37 +137,19 @@ if(NOT CUSTOM_CFLAGS)
 endif()
 
 # source files
-set(CLI_Includes src/gmic.h)
 set(CLI_Sources src/gmic.cpp)
 
-if(MINGW)
-  list(APPEND EXTRA_LIBRARIES "-Wl,--stack,16777216")
-else()
-  list(APPEND EXTRA_LIBRARIES "-lpthread")
-endif()
-
-
 if(BUILD_LIB)
-  add_library(libgmic SHARED ${CLI_Includes} ${CLI_Sources})
-  add_dependencies(libgmic gmic_extra_headers)
-  set_target_properties(libgmic PROPERTIES COMPILE_FLAGS "${CLI_COMPILE_FLAGS}")
+  add_library(libgmic SHARED ${CLI_Sources})
   set_target_properties(libgmic PROPERTIES SOVERSION "1" OUTPUT_NAME "gmic")
-  if(NOT APPLE)
-    #the following is automatic unless NO_SONAME is set
-    #set_target_properties(libgmic PROPERTIES LINK_FLAGS "-Wl,-soname,libgmic.so.1")
-  endif()
   target_link_libraries(libgmic
-    ${X11_LIBRARIES}
-    ${TIFF_LIBRARIES}
-    ${PNG_LIBRARIES}
-    ${JPEG_LIBRARIES}
-    ${GRAPHICSMAGICK_LIBRARIES}
-    ${OPENEXR_LIBRARIES}
-    ${OPENCV_LIBRARIES}
-    ${ZLIB_LIBRARIES}
-    ${CURL_LIBRARIES}
-    ${FFTW3_LIBRARIES}
-    ${EXTRA_LIBRARIES}
+    CImg::CImg
+    GMicStdlib::Stdlib
+  )
+  target_include_directories(libgmic
+    PUBLIC
+      $<INSTALL_INTERFACE:include>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
   )
 
   install(TARGETS libgmic EXPORT GmicTargets
@@ -319,22 +163,16 @@ endif()
 
 
 if(BUILD_LIB_STATIC)
-  add_library(libgmicstatic STATIC ${CLI_Includes} ${CLI_Sources})
-  add_dependencies(libgmicstatic gmic_extra_headers)
-  set_target_properties(libgmicstatic PROPERTIES COMPILE_FLAGS "${CLI_COMPILE_FLAGS}")
+  add_library(libgmicstatic STATIC ${CLI_Sources})
   set_target_properties(libgmicstatic PROPERTIES OUTPUT_NAME "gmic")
   target_link_libraries(libgmicstatic
-    ${X11_LIBRARIES}
-    ${TIFF_LIBRARIES}
-    ${PNG_LIBRARIES}
-    ${JPEG_LIBRARIES}
-    ${GRAPHICSMAGICK_LIBRARIES}
-    ${OPENEXR_LIBRARIES}
-    ${OPENCV_LIBRARIES}
-    ${ZLIB_LIBRARIES}
-    ${CURL_LIBRARIES}
-    ${FFTW3_LIBRARIES}
-    ${EXTRA_LIBRARIES}
+    CImg::CImg
+    GMicStdlib::Stdlib
+  )
+  target_include_directories(libgmicstatic
+    PUBLIC
+      $<INSTALL_INTERFACE:include>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
   )
 
   install(TARGETS libgmicstatic EXPORT GmicTargets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
@@ -343,32 +181,13 @@ endif()
 
 
 if(BUILD_CLI)
+  add_executable(gmic src/gmic_cli.cpp)
   if(ENABLE_DYNAMIC_LINKING)
-    add_executable(gmic ${CLI_Includes} src/gmic_cli.cpp)
-    add_dependencies(gmic gmic_extra_headers)
-    add_dependencies(gmic libgmic)
-    target_link_libraries(gmic
-      "libgmic"
-    )
+    target_link_libraries(gmic libgmic)
   else()
-    add_executable(gmic ${CLI_Includes} ${CLI_Sources} src/gmic_cli.cpp)
-    add_dependencies(gmic gmic_extra_headers)
-    target_link_libraries(gmic
-      ${X11_LIBRARIES}
-      ${TIFF_LIBRARIES}
-      ${PNG_LIBRARIES}
-      ${JPEG_LIBRARIES}
-      ${GRAPHICSMAGICK_LIBRARIES}
-      ${OPENEXR_LIBRARIES}
-      ${OPENCV_LIBRARIES}
-      ${ZLIB_LIBRARIES}
-      ${CURL_LIBRARIES}
-      ${FFTW3_LIBRARIES}
-      ${EXTRA_LIBRARIES}
-    )
+    target_link_libraries(gmic libgmicstatic)
   endif()
 
-  set_target_properties(gmic PROPERTIES COMPILE_FLAGS "${CLI_COMPILE_FLAGS}")
   install(TARGETS gmic RUNTIME DESTINATION bin LIBRARY DESTINATION lib)
 endif()
 

--- a/cmake/FindCImg.cmake
+++ b/cmake/FindCImg.cmake
@@ -1,0 +1,173 @@
+set(HEADER_URL "https://github.com/dtschump/CImg/raw/master/CImg.h")
+set(HEADER_DIR ${CMAKE_SOURCE_DIR}/src)
+set(HEADER_NAME CImg.h)
+set(HEADER_PATH ${HEADER_DIR}/${HEADER_NAME})
+
+# CImg.h header
+if(NOT EXISTS ${HEADER_PATH})
+  file(DOWNLOAD ${HEADER_URL} ${HEADER_PATH} STATUS download_status)
+
+  list(GET download_status 0 status_code)
+  if(NOT ${status_code} EQUAL 0)
+    message(FATAL_ERROR "Missing ${HEADER_NAME} and unable to obtain it. Please download it from ${HEADER_URL} and save it to src/ directory.")
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CImg
+  REQUIRED_VARS HEADER_PATH
+)
+
+# Build options
+option(ENABLE_CURL "Add support for curl" ON)
+option(ENABLE_X "Add support for X11" ON)
+option(ENABLE_FFMPEG "Add support for FFMpeg" ON)
+option(ENABLE_FFTW "Add support for FFTW" ON)
+option(ENABLE_GRAPHICSMAGICK "Add support for GrahicsMagick" ON)
+option(ENABLE_JPEG "Add support for handling images in Jpeg format" ON)
+option(ENABLE_OPENCV "Add support for OpenCV" ON)
+option(ENABLE_OPENEXR "Add support for handling images in EXR format" ON)
+option(ENABLE_OPENMP "Add support for parallel processing" ON)
+option(ENABLE_PNG "Add support for handling images in PNG format" ON)
+option(ENABLE_TIFF "Add support for handling images in Tiff format" ON)
+option(ENABLE_ZLIB "Add support for data compression via Zlib" ON)
+
+set(COMPILE_FLAGS)
+set(LINK_FLAGS)
+set(CLI_COMPILE_FLAGS)
+set(EXTRA_LIBRARY_TARGETS)
+
+## Add dependencies
+
+# OpenMP support
+if(ENABLE_OPENMP)
+  find_package(OpenMP)
+  if(OpenMP_FOUND)
+    list(APPEND COMPILE_FLAGS "cimg_use_openmp")
+    list(APPEND EXTRA_LIBRARY_TARGETS OpenMP::OpenMP_CXX)
+  endif()
+endif()
+
+# Zlib support
+if(ENABLE_ZLIB)
+  find_package(ZLIB)
+
+  if(ZLIB_FOUND)
+    list(APPEND COMPILE_FLAGS "cimg_use_zlib")
+    list(APPEND EXTRA_LIBRARY_TARGETS ZLIB::ZLIB)
+  endif()
+endif()
+
+# Curl support
+if(ENABLE_CURL)
+  find_package(CURL)
+
+  if(CURL_FOUND)
+    list(APPEND COMPILE_FLAGS "cimg_use_curl")
+    list(APPEND EXTRA_LIBRARY_TARGETS CURL::libcurl)
+  endif()
+endif()
+
+# X11 support
+if(ENABLE_X)
+  find_package(X11)
+
+  if(X11_FOUND)
+    list(APPEND COMPILE_FLAGS "cimg_display=1" "cimg_appname=\"gmic\"")
+    list(APPEND EXTRA_LIBRARY_TARGETS X11::X11)
+  else()
+    list(APPEND COMPILE_FLAGS "cimg_display=0" "cimg_appname=\"gmic\"")
+  endif()
+
+  if(X11_XShm_FOUND)
+    list(APPEND COMPILE_FLAGS "cimg_use_xshm")
+  endif()
+endif()
+
+if(ENABLE_FFTW)
+  find_package(Fftw)
+
+  if(Fftw_FOUND)
+    list(APPEND COMPILE_FLAGS "cimg_use_fftw3")
+    list(APPEND EXTRA_LIBRARY_TARGETS Fftw::Fftw)
+
+    if(TARGET Fftw::Threads)
+      list(APPEND COMPILE_FLAGS "cimg_use_fftw3_singlethread")
+    else()
+      list(APPEND EXTRA_LIBRARY_TARGETS Fftw::Threads)
+    endif()
+  endif()
+endif()
+
+if(ENABLE_OPENCV)
+  find_package(OpenCV)
+
+  if(OPENCV_FOUND)
+    list(APPEND CLI_COMPILE_FLAGS "cimg_use_opencv")
+    list(APPEND EXTRA_LIBRARY_TARGETS OpenCV::OpenCV)
+  endif()
+endif()
+
+if(ENABLE_GRAPHICSMAGICK)
+  find_package(GraphicsMagick)
+
+  if(GraphicsMagick_FOUND)
+    list(APPEND CLI_COMPILE_FLAGS "cimg_use_magick")
+    list(APPEND EXTRA_LIBRARY_TARGETS GraphicsMagick::GraphicsMagick++)
+  endif()
+endif()
+
+if(ENABLE_TIFF)
+  find_package(TIFF)
+
+  if(TIFF_FOUND)
+    list(APPEND CLI_COMPILE_FLAGS "cimg_use_tiff")
+    list(APPEND EXTRA_LIBRARY_TARGETS TIFF::TIFF)
+  endif()
+endif()
+
+if(ENABLE_PNG)
+  find_package(PNG)
+
+  if(PNG_FOUND)
+    list(APPEND CLI_COMPILE_FLAGS "cimg_use_png")
+    list(APPEND EXTRA_LIBRARY_TARGETS PNG::PNG)
+  endif()
+endif()
+
+if(ENABLE_JPEG)
+  find_package(JPEG)
+
+  if(JPEG_FOUND)
+    list(APPEND CLI_COMPILE_FLAGS "cimg_use_jpeg")
+    list(APPEND EXTRA_LIBRARY_TARGETS JPEG::JPEG)
+  endif()
+endif()
+
+if(ENABLE_OPENEXR)
+  find_package(OpenEXR)
+
+  if(OpenEXR_FOUND)
+    list(APPEND CLI_COMPILE_FLAGS "cimg_use_openexr")
+    list(APPEND EXTRA_LIBRARY_TARGETS OpenEXR::OpenEXR)
+  endif()
+endif()
+
+if(MINGW)
+  list(APPEND COMPILE_FLAGS "-Wl,--stack,16777216")
+endif()
+
+find_package(Threads)
+if(Threads_FOUND)
+  list(APPEND EXTRA_LIBRARY_TARGETS Threads::Threads)
+endif()
+
+
+# Library definition
+
+add_library(CImg::CImg INTERFACE IMPORTED)
+
+target_compile_definitions(CImg::CImg INTERFACE ${COMPILE_FLAGS} ${CLI_COMPILE_FLAGS})
+target_link_options(CImg::CImg INTERFACE ${LINK_FLAGS})
+target_link_libraries(CImg::CImg INTERFACE ${EXTRA_LIBRARY_TARGETS})
+target_include_directories(CImg::CImg INTERFACE ${HEADER_DIR})

--- a/cmake/FindFftw.cmake
+++ b/cmake/FindFftw.cmake
@@ -1,0 +1,22 @@
+find_package(PkgConfig)
+
+pkg_check_modules(FFTW3 fftw3>=3.0)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Fftw
+  REQUIRED_VARS FFTW3_LIBRARIES
+)
+
+add_library(Fftw::Fftw INTERFACE IMPORTED)
+set_target_properties(Fftw::Fftw PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${FFTW3_INCLUDE_DIRS}"
+  INTERFACE_LINK_LIBRARIES "${FFTW3_LIBRARIES}"
+)
+
+find_library(FFTW3_THREADS_LIB fftw3_threads PATHS ${FFTW3_LIBRARY_DIRS})
+if(NOT FFTW3_THREADS_LIB STREQUAL "FFTW3_THREADS_LIB-NOTFOUND")
+  add_library(Fftw::Threads INTERFACE IMPORTED)
+  set_target_properties(Fftw::Threads PROPERTIES
+    INTERFACE_LINK_LIBRARIES "-lfftw3_threads"
+  )
+endif()

--- a/cmake/FindGMicStdlib.cmake
+++ b/cmake/FindGMicStdlib.cmake
@@ -1,0 +1,25 @@
+set(HEADER_URL "https://gmic.eu/gmic_stdlib.h")
+set(HEADER_DIR ${CMAKE_SOURCE_DIR}/src)
+set(HEADER_NAME gmic_stdlib.h)
+set(HEADER_PATH ${HEADER_DIR}/${HEADER_NAME})
+
+# gmic_stdlib.h header
+if(NOT EXISTS ${HEADER_PATH})
+  file(DOWNLOAD ${HEADER_URL} ${HEADER_PATH} STATUS download_status)
+
+  list(GET download_status 0 status_code)
+  if(NOT ${status_code} EQUAL 0)
+    message(FATAL_ERROR "Missing ${HEADER_NAME} and unable to obtain it. Please download it from ${HEADER_URL} and save it to src/ directory.")
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GMicStdlib
+  REQUIRED_VARS HEADER_PATH
+)
+
+add_library(GMicStdlib::Stdlib INTERFACE IMPORTED)
+
+set_target_properties(GMicStdlib::Stdlib PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${HEADER_DIR}"
+)

--- a/cmake/FindGraphicsMagick.cmake
+++ b/cmake/FindGraphicsMagick.cmake
@@ -1,0 +1,14 @@
+find_package(PkgConfig)
+
+pkg_check_modules(GRAPHICSMAGICK GraphicsMagick++)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GraphicsMagick
+  REQUIRED_VARS GRAPHICSMAGICK_LIBRARIES
+)
+
+add_library(GraphicsMagick::GraphicsMagick++ INTERFACE IMPORTED)
+set_target_properties(GraphicsMagick::GraphicsMagick++ PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${GRAPHICSMAGICK_INCLUDE_DIRS}"
+  INTERFACE_LINK_LIBRARIES "${GRAPHICSMAGICK_LIBRARIES}"
+)

--- a/cmake/FindOpenCV.cmake
+++ b/cmake/FindOpenCV.cmake
@@ -1,0 +1,15 @@
+# The CMake modules shipped with OpenCV do not contain targets.
+find_package(PkgConfig)
+
+pkg_check_modules(OPENCV opencv)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OpenCV
+  REQUIRED_VARS OPENCV_LIBRARIES
+)
+
+add_library(OpenCV::OpenCV INTERFACE IMPORTED)
+set_target_properties(OpenCV::OpenCV PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${OPENCV_INCLUDE_DIRS}"
+  INTERFACE_LINK_LIBRARIES "${OPENCV_LIBRARIES}"
+)

--- a/cmake/FindOpenCV.cmake
+++ b/cmake/FindOpenCV.cmake
@@ -1,15 +1,28 @@
 # The CMake modules shipped with OpenCV do not contain targets.
 find_package(PkgConfig)
 
-pkg_check_modules(OPENCV opencv)
+pkg_check_modules(OPENCV opencv4)
+
+if(NOT OPENCV_FOUND)
+  pkg_check_modules(OPENCV opencv)
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(OpenCV
   REQUIRED_VARS OPENCV_LIBRARIES
 )
 
+# OpenCV 4 can contain broken path in .pc file so we need to filter it.
+# https://github.com/opencv/opencv/pull/17377
+set(OPENCV_VALID_INCLUDE_DIRS)
+foreach(dir ${OPENCV_INCLUDE_DIRS})
+  if(EXISTS ${dir})
+    list(APPEND OPENCV_VALID_INCLUDE_DIRS ${dir})
+  endif()
+endforeach()
+
 add_library(OpenCV::OpenCV INTERFACE IMPORTED)
 set_target_properties(OpenCV::OpenCV PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${OPENCV_INCLUDE_DIRS}"
+  INTERFACE_INCLUDE_DIRECTORIES "${OPENCV_VALID_INCLUDE_DIRS}"
   INTERFACE_LINK_LIBRARIES "${OPENCV_LIBRARIES}"
 )

--- a/cmake/FindOpenEXR.cmake
+++ b/cmake/FindOpenEXR.cmake
@@ -1,0 +1,14 @@
+find_package(PkgConfig)
+
+pkg_check_modules(OPENEXR OpenEXR)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OpenEXR
+  REQUIRED_VARS OPENEXR_LIBRARIES
+)
+
+add_library(OpenEXR::OpenEXR INTERFACE IMPORTED)
+set_target_properties(OpenEXR::OpenEXR PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${OPENEXR_INCLUDE_DIRS}"
+  INTERFACE_LINK_LIBRARIES "${OPENEXR_LIBRARIES}"
+)

--- a/src/gmic.h
+++ b/src/gmic.h
@@ -219,7 +219,7 @@ inline double gmic_mp_setname(const unsigned int ind, const char *const str,
 #ifndef cimg_appname
 #define cimg_appname "gmic"
 #endif
-#include "./CImg.h"
+#include "CImg.h"
 
 #if cimg_OS==2
 #include <process.h>


### PR DESCRIPTION
Passing compiler and linker flags manually is not recommended practice any more. Instead, every dependency is supposed to be a separate build target (only marked as imported) that will be imported using find_package and will pass appropriate flags as needed.

https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/

In particular, this meant creating CMake modules for dependencies whose modules are not shipped with CMake, do not provide their own CMake modules, or the modules do not export targets yet.

It seems to me G'Mic does not actually depend on much other than CImg and that pulls all the dependencies, so I moved the feature flags to the newly created CImg.cmake module.

<!-- On that note, I am installing the header-only libraries CImg.h and gmic_stdlib.h to their own directories in the build directory for easier cleanup. That meant I had to slightly change the include path in the Makefile too. -->

I also switched to CMake's LTO module (called IPO) since we no longer pass linker flags to G'Mic targets.

Finally, I simplified the CLI target to only depend on the appropriate libgmic.