### PR TITLE
cmake: bump minimal version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@
 #  knowledge of the CeCILL and CeCILL-C licenses and that you accept its terms.
 #
 
-cmake_minimum_required(VERSION 3.9.4)
+cmake_minimum_required(VERSION 3.14.0)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
   message("Build directory is equal to source directory. Binaries will be put in the src directory.")


### PR DESCRIPTION
In the CMake modernization changeset, we started using features that are only available in CMake 3.14. Let's properly declare the dependency.

Fixes: https://github.com/dtschump/gmic/issues/229