### PR TITLE
Fix image layer name in fx_stylize

### DIFF
--- a/src/gmic_stdlib.gmic
+++ b/src/gmic_stdlib.gmic
@@ -34124,7 +34124,7 @@ fx_stylize :
     fi
     if $4 wsiz=${"fitscreen "{0,[w,h]}} w[0] $wsiz is_window={*} fi
     stylize[0] .,${5-9},$15,$init_resolution,${17-22},$patch_penalization,${24-26},$match_colors
-    k[0,1] nm[0] $nm0
+    k[0,1] nm[0] ${-gui_layer_name}
     if $is_window" && "!{*} break fi
   endl done
   rm. # Remove style image


### PR DESCRIPTION
This PR is a very simple fix for the image layer name in `fx_stylize`. The `$nm0` variable was never set in the command code.

Fixes #260