### PR TITLE
Fix MinGW-w64 build

### DIFF
--- a/cmake/FindCImg.cmake
+++ b/cmake/FindCImg.cmake
@@ -156,7 +156,7 @@ if(ENABLE_OPENEXR)
 endif()
 
 if(MINGW)
-  list(APPEND COMPILE_FLAGS "-Wl,--stack,16777216")
+  list(APPEND LINK_FLAGS "-Wl,--stack,16777216")
 endif()
 
 find_package(Threads)


### PR DESCRIPTION
The linker flag for increasing the stack size was incorrectly set as compile definition.

<details>
  <summary>Details</summary>

```
cd /data/mxe/tmp-vips-gmic-x86_64-w64-mingw32/vips-gmic-6e102ce.build_/_deps/gmic-build && /data/mxe/usr/bin/x86_64-w64-mingw32-g++ -D-Wl,--stack,16777216 -Dcimg_use_zlib @CMakeFiles/libgmicstatic.dir/includes_CXX.rsp -s -O3 -fPIC -Ofast -Dgmic_build -Dcimg_use_vt100 -Dgmic_is_parallel -Dcimg_use_abort -Wno-error=narrowing -fno-ipa-sra -fpermissive -std=gnu++11 -o CMakeFiles/libgmicstatic.dir/src/gmic.cpp.obj -c /data/mxe/tmp-vips-gmic-x86_64-w64-mingw32/vips-gmic-6e102ce.build_/_deps/gmic-src/src/gmic.cpp
<command-line>: error: macro names must be identifiers
```
</details>