### PR TITLE
Fix Clang build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,8 +99,12 @@ set(CMAKE_POSITION_INDEPENDENT_CODE True)
 set(COMPILE_FLAGS "-Dgmic_build -Dcimg_use_vt100 -Dgmic_is_parallel -Dcimg_use_abort")
 if(APPLE)
    set(COMPILE_FLAGS "${COMPILE_FLAGS} -mmacosx-version-min=10.8 -stdlib=libc++ -Wno-error=c++11-narrowing -Wc++11-extensions -fpermissive")
-else()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU") 
+  # GCC
   set(COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-error=narrowing -fno-ipa-sra -fpermissive")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  # Clang
+  set(COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-error=narrowing -fpermissive")
 endif()
 
 if(NOT "${PRERELEASE_TAG}" STREQUAL "")


### PR DESCRIPTION
The `-fno-ipa-sra` compiler option is not available on Clang. See:
```
clang-11: error: unknown argument: '-fno-ipa-sra'
```