### PR TITLE
Do not claim copyright for future years

### DIFF
--- a/src/gmic_stdlib.gmic
+++ b/src/gmic_stdlib.gmic
@@ -1514,7 +1514,7 @@ reference_header_ascii :
       "        "${_vt100_c}${_vt100_b}"Version "${-strver}$strprerelease$_vt100_n\n\
       "        "$_vt100_g$_vt100_u"(https://gmic.eu)"$_vt100_n\n\
       \n\
-      "        Copyright (c) 2008-"{date(0)}", David Tschumperlé / GREYC / CNRS."\n\
+      "        Copyright (c) 2008-2021, David Tschumperlé / GREYC / CNRS."\n\
       "        "$_vt100_g$_vt100_u"(https://www.greyc.fr)"$_vt100_n
   +e[] $str
 


### PR DESCRIPTION
Without this patch, building this software in 2036 produced a
`/usr/share/man/man1/gmic.1` that contained
```
Copyright (c) 2008-2036, David Tschumperlé / GREYC / CNRS.
```

See also on this topic:
https://stackoverflow.com/questions/2390230/do-copyright-dates-need-to-be-updated

Additionally, this helps reproducible builds of this software.
See https://reproducible-builds.org/ for why this is good.

An alternative approach could use mtime of relevant input files.