### PR TITLE
cmake: Set target compile flags correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,15 +96,15 @@ endif()
 # compile flags
 set(CMAKE_POSITION_INDEPENDENT_CODE True)
 
-set(COMPILE_FLAGS "-Dgmic_build -Dcimg_use_vt100 -Dgmic_is_parallel -Dcimg_use_abort")
+list(APPEND GMIC_CXX_COMPILE_FLAGS -Dgmic_build -Dcimg_use_vt100 -Dgmic_is_parallel -Dcimg_use_abort)
 if(APPLE)
-   set(COMPILE_FLAGS "${COMPILE_FLAGS} -mmacosx-version-min=10.8 -stdlib=libc++ -Wno-error=c++11-narrowing -Wc++11-extensions -fpermissive")
+    list(APPEND GMIC_CXX_COMPILE_FLAGS -mmacosx-version-min=10.8 -stdlib=libc++ -Wno-error=c++11-narrowing -Wc++11-extensions -fpermissive)
 else()
-  set(COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-error=narrowing -fno-ipa-sra -fpermissive")
+    list(APPEND GMIC_CXX_COMPILE_FLAGS -Wno-error=narrowing -fno-ipa-sra -fpermissive)
 endif()
 
 if(NOT "${PRERELEASE_TAG}" STREQUAL "")
-  set(COMPILE_FLAGS "${COMPILE_FLAGS} -Dgmic_prerelease=\"${PRERELEASE_TAG}\"")
+    list(APPEND GMIC_CXX_COMPILE_FLAGS "-Dgmic_prerelease=\"${PRERELEASE_TAG}\"")
 endif()
 
 if (ENABLE_LTO)
@@ -126,14 +126,20 @@ if(ENABLE_DYNAMIC_LINKING)
   set(CMAKE_SKIP_RPATH TRUE)
 endif()
 
-set(CMAKE_CXX_FLAGS_DEBUG "-g -ansi -Wall -Wextra -pedantic -Dcimg_verbosity=3 ${COMPILE_FLAGS}")
-set(CMAKE_CXX_FLAGS_RELEASE "${COMPILE_FLAGS}")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g ${COMPILE_FLAGS}")
+string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
+if (${CMAKE_BUILD_TYPE_LOWER} STREQUAL "debug")
+    list(PREPEND GMIC_CXX_COMPILE_FLAGS -g -ansi -Wall -Wextra -pedantic -Dcimg_verbosity=3)
+endif()
+if (${CMAKE_BUILD_TYPE_LOWER} STREQUAL "relwithdebinfo")
+    list(PREPEND GMIC_CXX_COMPILE_FLAGS -g)
+endif()
 
-if(NOT CUSTOM_CFLAGS)
-  set(CMAKE_CXX_FLAGS_DEBUG "-Og ${CMAKE_CXX_FLAGS_DEBUG}")
-  set(CMAKE_CXX_FLAGS_RELEASE "-Ofast ${CMAKE_CXX_FLAGS_RELEASE}")
-  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-Ofast ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+if (NOT CUSTOM_CFLAGS)
+    if (${CMAKE_BUILD_TYPE_LOWER} STREQUAL "debug")
+        list(PREPEND GMIC_CXX_COMPILE_FLAGS -Og)
+    else()
+        list(PREPEND GMIC_CXX_COMPILE_FLAGS -Ofast)
+    endif()
 endif()
 
 # source files
@@ -141,6 +147,7 @@ set(CLI_Sources src/gmic.cpp)
 
 if(BUILD_LIB)
   add_library(libgmic SHARED ${CLI_Sources})
+  target_compile_options(libgmic PRIVATE ${GMIC_CXX_COMPILE_FLAGS})
   set_target_properties(libgmic PROPERTIES SOVERSION "1" OUTPUT_NAME "gmic")
   target_link_libraries(libgmic
     CImg::CImg
@@ -164,6 +171,7 @@ endif()
 
 if(BUILD_LIB_STATIC)
   add_library(libgmicstatic STATIC ${CLI_Sources})
+  target_compile_options(libgmicstatic PRIVATE ${GMIC_CXX_COMPILE_FLAGS})
   set_target_properties(libgmicstatic PROPERTIES OUTPUT_NAME "gmic")
   target_link_libraries(libgmicstatic
     CImg::CImg
@@ -182,6 +190,7 @@ endif()
 
 if(BUILD_CLI)
   add_executable(gmic src/gmic_cli.cpp)
+  target_compile_options(gmic PRIVATE ${GMIC_CXX_COMPILE_FLAGS})
   if(ENABLE_DYNAMIC_LINKING)
     target_link_libraries(gmic libgmic)
   else()


### PR DESCRIPTION
This will not overwrite what you set with CMAKE_CXX_FLAGS on the
command line. Currently flags set by distributions are ignored when
packaging gmic.