### PR TITLE
CMake: ensure versioned `gmic_stdlib.h` is downloaded

### DIFF
--- a/cmake/FindCImg.cmake
+++ b/cmake/FindCImg.cmake
@@ -1,5 +1,5 @@
 set(HEADER_URL "https://github.com/dtschump/CImg/raw/master/CImg.h")
-set(HEADER_DIR ${CMAKE_SOURCE_DIR}/src)
+set(HEADER_DIR ${PROJECT_SOURCE_DIR}/src)
 set(HEADER_NAME CImg.h)
 set(HEADER_PATH ${HEADER_DIR}/${HEADER_NAME})
 

--- a/cmake/FindGMicStdlib.cmake
+++ b/cmake/FindGMicStdlib.cmake
@@ -1,5 +1,7 @@
-set(HEADER_URL "https://gmic.eu/gmic_stdlib.h")
-set(HEADER_DIR ${CMAKE_SOURCE_DIR}/src)
+file(STRINGS ${PROJECT_SOURCE_DIR}/src/gmic.h GMIC_VERSION REGEX "#define gmic_version [0-9]+")
+string(REGEX MATCH "[0-9]+" GMIC_VERSION ${GMIC_VERSION})
+set(HEADER_URL "https://gmic.eu/gmic_stdlib${GMIC_VERSION}.h")
+set(HEADER_DIR ${PROJECT_SOURCE_DIR}/src)
 set(HEADER_NAME gmic_stdlib.h)
 set(HEADER_PATH ${HEADER_DIR}/${HEADER_NAME})
 


### PR DESCRIPTION
And prefer to use `PROJECT_SOURCE_DIR` instead of `CMAKE_SOURCE_DIR`.

Note that I also had to apply this patch to build from the [`v.3.0.0`](https://github.com/dtschump/gmic/releases/tag/v.3.0.0) tag:
```diff
--- a/cmake/FindCImg.cmake
+++ b/cmake/FindCImg.cmake
@@ -1,4 +1,4 @@
-set(HEADER_URL "https://github.com/dtschump/CImg/raw/master/CImg.h")
+set(HEADER_URL "https://github.com/dtschump/CImg/raw/v.3.0.0/CImg.h")
 set(HEADER_DIR ${PROJECT_SOURCE_DIR}/src)
 set(HEADER_NAME CImg.h)
 set(HEADER_PATH ${HEADER_DIR}/${HEADER_NAME})
```
(to avoid downloading a newer `CImg.h`, which would result in many compiler errors)

This PR targets the `develop` branch as mentioned in PR #286.