### PR TITLE
Fix build with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ endif()
 # compile flags
 set(CMAKE_POSITION_INDEPENDENT_CODE True)
 
-list(APPEND GMIC_CXX_COMPILE_FLAGS -Dgmic_core -Dcimg_use_vt100 -Dgmic_is_parallel -Dcimg_use_abort)
+list(APPEND GMIC_CXX_COMPILE_FLAGS -Dcimg_use_vt100 -Dgmic_is_parallel -Dcimg_use_abort)
 if(APPLE)
     list(APPEND GMIC_CXX_COMPILE_FLAGS -mmacosx-version-min=10.8 -stdlib=libc++ -Wno-error=c++11-narrowing -Wc++11-extensions -fpermissive)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
@@ -149,7 +149,7 @@ set(CLI_Sources src/gmic.cpp)
 
 if(BUILD_LIB)
   add_library(libgmic SHARED ${CLI_Sources})
-  target_compile_options(libgmic PRIVATE ${GMIC_CXX_COMPILE_FLAGS})
+  target_compile_options(libgmic PRIVATE ${GMIC_CXX_COMPILE_FLAGS} -Dgmic_core)
   set_target_properties(libgmic PROPERTIES SOVERSION "1" OUTPUT_NAME "gmic")
   target_link_libraries(libgmic
     CImg::CImg
@@ -173,7 +173,7 @@ endif()
 
 if(BUILD_LIB_STATIC)
   add_library(libgmicstatic STATIC ${CLI_Sources})
-  target_compile_options(libgmicstatic PRIVATE ${GMIC_CXX_COMPILE_FLAGS})
+  target_compile_options(libgmicstatic PRIVATE ${GMIC_CXX_COMPILE_FLAGS} -Dgmic_core)
   set_target_properties(libgmicstatic PROPERTIES OUTPUT_NAME "gmic")
   target_link_libraries(libgmicstatic
     CImg::CImg


### PR DESCRIPTION
Only define gmic_core when building the library, matching the Makefile.

Fixes #363