### PR TITLE
input_cached: allow using GMIC_SYSTEM_PATH on Windows

### DIFF
--- a/src/gmic_stdlib.gmic
+++ b/src/gmic_stdlib.gmic
@@ -3796,6 +3796,8 @@ _input_glob :
   if !${-is_windows}
     path_test4=/usr/share/gmic/
     path_test5=$g_path_unix
+  else
+    path_test4=$g_path_unix
   fi
   file_found=0
   repeat inf {


### PR DESCRIPTION
This allows specifying a folder, possibly created at install time, where
the app keeps an offline copy of the G'MIC CLUT files.

Note: this is a counterpart of https://github.com/dtschump/CImg/pull/340, which adds a Powershell fallback in case this one isn't used.

Fixes #374

See https://krita-artists.org/t/unknown-filename-gmic-qt/37813

See https://discuss.pixls.us/t/system-path-for-gmic-film-cluts-gmz-file/3055